### PR TITLE
use `html` instead of `text` method in the message open

### DIFF
--- a/cms/static/cms/js/modules/cms.modal.js
+++ b/cms/static/cms/js/modules/cms.modal.js
@@ -567,7 +567,7 @@ $(document).ready(function () {
 
 				// show messages in toolbar if provided
 				var messages = iframe.contents().find('.messagelist li');
-					if(messages.length) CMS.API.Toolbar.openMessage(messages.eq(0).text());
+					if(messages.length) CMS.API.Toolbar.openMessage(messages.eq(0).html());
 					messages.remove();
 				var contents = iframe.contents();
 


### PR DESCRIPTION
modern browsers will use escaped version of the text, meaning
`&gt;script&lt;alert(1);&gt;/script&lt;` would actually render script
tag with an alert in the message

this will have to be migratied to 3.0 as well
